### PR TITLE
Adjust tsup configuration

### DIFF
--- a/package/tsup.config.ts
+++ b/package/tsup.config.ts
@@ -11,5 +11,9 @@ export default defineConfig({
   minify: true,
   sourcemap: true,
   keepNames: true,
-  external: ["@tiptap/*", ...Object.keys(pkg.peerDependencies)],
+  external: [
+    "@tiptap/*",
+    ...Object.keys(pkg.dependencies),
+    ...Object.keys(pkg.peerDependencies),
+  ],
 });

--- a/package/tsup.config.ts
+++ b/package/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   shims: true,
   skipNodeModulesBundle: true,
   clean: true,
-  minify: true,
+  minify: false,
   sourcemap: true,
   keepNames: true,
   external: [

--- a/package/tsup.config.ts
+++ b/package/tsup.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   clean: true,
   minify: false,
   sourcemap: true,
-  keepNames: true,
   external: [
     "@tiptap/*",
     ...Object.keys(pkg.dependencies),


### PR DESCRIPTION
Noticed `uuid` was being bundled despite being listed as dependencies, the only packages we should ever bundle is if it's listed under `devDependencies`, so let's add `dependencies` as external.

Disable minification as well because it usually doesn't make sense for libraries as it makes things like patching harder to do (currently patching from Buttondown to see if it fixes https://github.com/buttondown/roadmap/issues/2919, before making patches here) and necessitates sourcemaps (which we still do provide, but it's nice for the cases where sourcemaps fails on us)