### PR TITLE
Scroll into footnote directly instead of via ProseMirror

### DIFF
--- a/package/src/footnotes/footnote.ts
+++ b/package/src/footnotes/footnote.ts
@@ -72,8 +72,9 @@ const Footnote = ListItem.extend({
                 .setTextSelection(
                   matchedFootnote.from + matchedFootnote.content.size,
                 )
-                .scrollIntoView()
                 .run();
+
+              matchedFootnote.element.scrollIntoView();
               return true;
             }
             return false;


### PR DESCRIPTION
ref: https://github.com/buttondown/roadmap/issues/2919

Scroll to the footnote on our own instead of via ProseMirror, this should allow us to configure `scroll-margin` to account for the bottom toolbar that we have in Buttondown's editor (though in my testing this is enough, no additional margins necessary)