### PR TITLE
Fix history & optionally add the footnotes list

### DIFF
--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -9,7 +9,7 @@ const extensions = [
     document: false,
   }),
   Document.extend({
-    content: "block+ footnotes",
+    content: "block+ footnotes?",
   }),
   Placeholder.configure({
     placeholder: "Start typing here...",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiptap-footnotes",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A footnotes extension for Tiptap",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package/src/footnotes/footnotes.ts
+++ b/package/src/footnotes/footnotes.ts
@@ -1,21 +1,6 @@
 import OrderedList from "@tiptap/extension-ordered-list";
-import { Fragment, Node } from "@tiptap/pm/model";
-
-import { getFootnotes, updateFootnoteReferences } from "./utils";
 import FootnoteRules from "./rules";
 
-declare module "@tiptap/core" {
-  interface Commands<ReturnType> {
-    footnotes: {
-      /**
-       * updates the footnotes definition list
-       * @param insertNew if set to true, we insert a new footnote reference at the current anchor
-       * @example editor.commands.updateFootnotesList(false)
-       */
-      updateFootnotesList: (insertNew: boolean) => ReturnType;
-    };
-  }
-}
 const Footnotes = OrderedList.extend({
   name: "footnotes",
   group: "", // removed the default group of the ordered list extension
@@ -70,78 +55,7 @@ const Footnotes = OrderedList.extend({
     };
   },
   addCommands() {
-    return {
-      // updateFootnotesList takes a list of footnoteReferences and compares them to the current footnotes.
-      // each footnote reference node contains a unique uuid that matches the footnote it references to. So here, we are basically comparing the ids of the references to the current footnotes.
-      // If there is a footnote that has no corresponding reference, we delete it. And if there is a reference that has no corresponding footnote, we add a new footnote list item for it.
-
-      // in this command, we also insert new footnotes references. This is because we want to group the new footnote insertions w/ the footnote list adjustments in the history.
-      // Doing it this way makes it so that when a user inserts a new footnote reference, then undoes that, the footnote will also be removed.
-      updateFootnotesList:
-        (insertNew = false) =>
-          ({ tr, state, dispatch }) => {
-            if (!dispatch) return false;
-            tr.setMeta("ignoreChanges", true);
-
-            // this command updates the footnote reference numbers (based on their order), inserts a new footnote if insertNew == true, and returns the updated list of footnodeReferences
-            let footnoteReferences = updateFootnoteReferences(
-              tr,
-              state,
-              insertNew,
-            );
-
-            const footnoteType = state.schema.nodes.footnote;
-            const emptyParagraph = state.schema.nodeFromJSON({
-              type: "paragraph",
-              content: [],
-            });
-
-            const { footnotesRange, footnotes } = getFootnotes(tr);
-
-            // a mapping of footnote id -> footnote node
-            const footnoteIds: { [key: string]: Node } = footnotes.reduce(
-              (obj, footnote) => {
-                obj[footnote.attrs["data-id"]] = footnote;
-                return obj;
-              },
-              {} as any,
-            );
-
-            const newFootnotes: Node[] = [];
-
-            for (let i = 0; i < footnoteReferences.length; i++) {
-              let ref = footnoteReferences[i];
-              // if there is a footnote w/ the same id as this `ref`, we preserve its content and update its id attribute
-              if (ref.attrs["data-id"] in footnoteIds) {
-                let footnote = footnoteIds[ref.attrs["data-id"]];
-                newFootnotes.push(
-                  footnoteType.create(
-                    { ...footnote.attrs, id: `fn:${i + 1}` },
-                    footnote.content,
-                  ),
-                );
-              } else {
-                let newNode = footnoteType.create(
-                  {
-                    "data-id": ref.attrs["data-id"],
-                    id: `fn:${i + 1}`,
-                  },
-                  [emptyParagraph],
-                );
-                newFootnotes.push(newNode);
-              }
-            }
-
-            tr.replaceWith(
-              footnotesRange!.from + 1, // add 1 to point at the position after the opening ol tag
-              footnotesRange!.to - 1, // substract 1 to point to the position before the closing ol tag
-              Fragment.from(newFootnotes),
-            );
-
-            dispatch(tr);
-            return true;
-          },
-    };
+    return {};
   },
   addInputRules() {
     return [];

--- a/package/src/footnotes/reference.ts
+++ b/package/src/footnotes/reference.ts
@@ -2,6 +2,7 @@ import { mergeAttributes, Node } from "@tiptap/core";
 import { NodeSelection, Plugin, PluginKey } from "@tiptap/pm/state";
 
 import { v4 as uuid } from "uuid";
+import { updateFootnoteReferences } from "./utils";
 
 const REFNUM_ATTR = "data-reference-number";
 const REF_CLASS = "footnote-ref";
@@ -114,9 +115,10 @@ const FootnoteReference = Node.create({
     return {
       addFootnote:
         () =>
-        ({ commands }) => {
-          return commands.updateFootnotesList(true);
-        },
+          ({ state, tr }) => {
+            updateFootnoteReferences(tr, state, true);
+            return true;
+          },
     };
   },
 
@@ -130,10 +132,7 @@ const FootnoteReference = Node.create({
           const start = range.from;
           let end = range.to;
           if (match[1]) {
-            chain()
-              .deleteRange({ from: start, to: end })
-              .updateFootnotesList(true)
-              .run();
+            chain().deleteRange({ from: start, to: end }).addFootnote().run();
           }
         },
       },

--- a/package/src/footnotes/rules.ts
+++ b/package/src/footnotes/rules.ts
@@ -1,7 +1,7 @@
 import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { ReplaceStep } from "@tiptap/pm/transform";
 import { Extension, minMax } from "@tiptap/core";
-import { Node } from "@tiptap/pm/model";
+import { updateFootnotesList } from "./utils";
 
 const FootnoteRules = Extension.create({
   name: "footnoteRules",
@@ -39,45 +39,38 @@ const FootnoteRules = Extension.create({
           return !overSelected && footnoteCount <= 1;
         },
 
-        // this function below helps with one main thing: when a user deletes a footnote reference, then undoes that, the footnote that was deleted will be undone aswell.
-        // we do this by detecting if a user deleted a footnote reference node, and then appending a transaction that deletes the footnote corresponding to it (so that both transactions are grouped in the history & will be undone together)
+        // if there are some to the footnote references (added/deleted/dragged), append a transaction that updates the footnotes list accordingly
         appendTransaction(transactions, oldState, newState) {
           let newTr = newState.tr;
-          const deleteFootnoteIds: Set<string> = new Set();
-
+          let refsChanged = false; // true if the footnote references have been changed, false otherwise
           for (let tr of transactions) {
+            if (!tr.docChanged) continue;
+            if (refsChanged) break;
+
             for (let step of tr.steps) {
               if (!(step instanceof ReplaceStep)) continue;
+              if (refsChanged) break;
+
               const isDelete = step.from != step.to; // the user deleted items from the document (from != to & the step is a replace step)
               const isInsert = step.from === step.to && step.slice.size > 0;
 
-              let insertedRefIds: Set<string> = new Set();
-
-              // get the footnote refs inserted in this step (to make sure we don't delete them)
-              step.slice.content.descendants((node) => {
-                if (node?.type.name == "footnoteReference") {
-                  insertedRefIds.add(node.attrs["data-id"]);
-                }
-              });
-
-              // we detect a case for isInsert because of drag & drop operations. When a footnoteReference is dragged, 2 steps are performed: the reference is deleted from the current position and inserted at a new position
-              // We don't want to delete footnotes for these refs in that case, so we remove them from the deletedFootnoteIds set.
+              // check if any footnote references have been inserted
               if (isInsert) {
-                for (let id of insertedRefIds) {
-                  deleteFootnoteIds.delete(id);
-                }
-              }
-              if (isDelete) {
-                // get the deleted footnoteReference nodes & add their ids to the set
+                step.slice.content.descendants((node) => {
+                  if (node?.type.name == "footnoteReference") {
+                    refsChanged = true;
+                    return false;
+                  }
+                });
+              } else if (isDelete) {
+                // check if any footnote references have been deleted
                 tr.before.nodesBetween(
                   step.from,
                   Math.min(tr.before.content.size, step.to), // make sure to not go over the old document's limit
                   (node) => {
-                    if (
-                      node.type.name == "footnoteReference" &&
-                      !insertedRefIds.has(node.attrs["data-id"])
-                    ) {
-                      deleteFootnoteIds.add(node.attrs["data-id"]);
+                    if (node.type.name == "footnoteReference") {
+                      refsChanged = true;
+                      return false;
                     }
                   },
                 );
@@ -85,68 +78,15 @@ const FootnoteRules = Extension.create({
             }
           }
 
-          if (deleteFootnoteIds.size > 0) {
-            newTr.doc.descendants((node, pos) => {
-              if (node.type.name != "footnotes" && node.type.name != "footnote")
-                return false;
-              if (
-                node.type.name == "footnote" &&
-                deleteFootnoteIds.has(node.attrs["data-id"])
-              ) {
-                // we traverse through this footnote's content because it may contain footnote references.
-                // we want to delete the footnotes associated with these references, so we add them to the delete set.
-                node.content.descendants((node) => {
-                  if (node.type.name == "footnoteReference")
-                    deleteFootnoteIds.add(node.attrs["data-id"]);
-                });
-                newTr.delete(
-                  newTr.mapping.map(pos),
-                  newTr.mapping.map(pos) + node.nodeSize,
-                );
-              }
-            });
-
+          if (refsChanged) {
+            updateFootnotesList(newTr, newState);
             return newTr;
           }
+
           return null;
         },
       }),
     ];
-  },
-  //@ts-ignore
-  onUpdate: ({ transaction, editor }) => {
-    let prevFootnotesCount = 0;
-    let currentFootnotesCount = 0;
-    const footnoteNodes: any[] = [];
-    if (transaction.docChanged && !transaction.getMeta("ignoreChanges")) {
-      let needsUpdate = false;
-
-      transaction.doc.descendants((node: Node) => {
-        if (node.type.name == "footnoteReference") {
-          currentFootnotesCount += 1;
-          footnoteNodes.push(node);
-        }
-      });
-
-      transaction.before.descendants((node: Node) => {
-        if (node.type.name == "footnoteReference") {
-          // this if statement helps us detect if the reference order got changed.
-          if (
-            node.attrs.referenceNumber !=
-            footnoteNodes[prevFootnotesCount]?.attrs.referenceNumber
-          ) {
-            needsUpdate = true;
-            return false; // don't descend further
-          }
-
-          prevFootnotesCount += 1;
-        }
-      });
-
-      if (currentFootnotesCount != prevFootnotesCount || needsUpdate) {
-        editor.commands.updateFootnotesList();
-      }
-    }
   },
 });
 export default FootnoteRules;

--- a/package/src/footnotes/utils.ts
+++ b/package/src/footnotes/utils.ts
@@ -1,5 +1,5 @@
 import { EditorState, Transaction } from "@tiptap/pm/state";
-import { Node } from "@tiptap/pm/model";
+import { Fragment, Node } from "@tiptap/pm/model";
 
 import { v4 as uuid } from "uuid";
 
@@ -46,11 +46,11 @@ export function updateFootnoteReferences(
     nodes.push(newFootnote);
   }
 
-  // return the updated footnote references
+  // return the updated footnote references (in the order that they appear in the document)
   return nodes;
 }
 
-export function getFootnotes(tr: Transaction) {
+function getFootnotes(tr: Transaction) {
   let footnotesRange: { from: number; to: number } | undefined;
   const footnotes: Node[] = [];
   tr.doc.descendants((node, pos) => {
@@ -63,4 +63,91 @@ export function getFootnotes(tr: Transaction) {
     }
   });
   return { footnotesRange, footnotes };
+}
+
+// update the "footnotes" ordered list based on the footnote references in the document
+export function updateFootnotesList(tr: Transaction, state: EditorState) {
+  const footnoteReferences = updateFootnoteReferences(tr, state, false);
+
+  const footnoteType = state.schema.nodes.footnote;
+  const footnotesType = state.schema.nodes.footnotes;
+
+  const emptyParagraph = state.schema.nodeFromJSON({
+    type: "paragraph",
+    content: [],
+  });
+
+  const { footnotesRange, footnotes } = getFootnotes(tr);
+
+  // a mapping of footnote id -> footnote node
+  const footnoteIds: { [key: string]: Node } = footnotes.reduce(
+    (obj, footnote) => {
+      obj[footnote.attrs["data-id"]] = footnote;
+      return obj;
+    },
+    {} as any,
+  );
+
+  const newFootnotes: Node[] = [];
+
+  let footnoteRefIds = new Set(
+    footnoteReferences.map((ref) => ref.attrs["data-id"]),
+  );
+  const deleteFootnoteIds: Set<string> = new Set();
+  for (let footnote of footnotes) {
+    const id = footnote.attrs["data-id"];
+    if (!footnoteRefIds.has(id) || deleteFootnoteIds.has(id)) {
+      deleteFootnoteIds.add(id);
+      // we traverse through this footnote's content because it may contain footnote references.
+      // we want to delete the footnotes associated with these references, so we add them to the delete set.
+      footnote.content.descendants((node) => {
+        if (node.type.name == "footnoteReference")
+          deleteFootnoteIds.add(node.attrs["data-id"]);
+      });
+    }
+  }
+
+  for (let i = 0; i < footnoteReferences.length; i++) {
+    let refId = footnoteReferences[i].attrs["data-id"];
+
+    if (deleteFootnoteIds.has(refId)) continue;
+    // if there is a footnote w/ the same id as this `ref`, we preserve its content and update its id attribute
+    if (refId in footnoteIds) {
+      let footnote = footnoteIds[refId];
+      newFootnotes.push(
+        footnoteType.create(
+          { ...footnote.attrs, id: `fn:${i + 1}` },
+          footnote.content,
+        ),
+      );
+    } else {
+      let newNode = footnoteType.create(
+        {
+          "data-id": refId,
+          id: `fn:${i + 1}`,
+        },
+        [emptyParagraph],
+      );
+      newFootnotes.push(newNode);
+    }
+  }
+
+  if (newFootnotes.length == 0) {
+    // no footnotes in the doc, delete the "footnotes" node
+    if (footnotesRange) {
+      tr.delete(footnotesRange.from, footnotesRange.to);
+    }
+  } else if (!footnotesRange) {
+    // there is no footnotes node present in the doc, add it
+    tr.insert(
+      tr.doc.content.size,
+      footnotesType.create(undefined, Fragment.from(newFootnotes)),
+    );
+  } else {
+    tr.replaceWith(
+      footnotesRange!.from + 1, // add 1 to point at the position after the opening ol tag
+      footnotesRange!.to - 1, // substract 1 to point to the position before the closing ol tag
+      Fragment.from(newFootnotes),
+    );
+  }
 }


### PR DESCRIPTION
closes https://github.com/buttondown/roadmap/issues/3033

Currently, we rely on the `footnotes` node to always be present in the document. This PR adds support for optionally inserting/deleting the footnotes list depending on the state of the footnotes references, making you able to define your root node like this:

```typescript
Document.extend({
        content: "block+ footnotes?",
}),
```

Adding this feature required a slight refactor of our current implementation, which happens to also fix a few history issues that required you to perform an undo/redo twice for the action to be performed. The most notable change is that all changes to the footnotes list are now `appendTransactions` rather than separate transactions.


**Breaking changes:**
the `updateFootnotesList` command is now removed and has been refactored as a utility function in `utils.ts`.
