### PR TITLE
Fix for loading existing footnotes

### DIFF
--- a/package/src/footnotes/footnotes.ts
+++ b/package/src/footnotes/footnotes.ts
@@ -21,7 +21,7 @@ const Footnotes = OrderedList.extend({
   parseHTML() {
     return [
       {
-        tag: "ol:has(.footnotes)",
+        tag: "ol.footnotes",
         priority: 1000,
       },
     ];


### PR DESCRIPTION
Fix the selector used to detect existing footnotes in an HTML document.

I verified that, with this fix, the documents correctly load into Tiptap with the footnote functionality enabled.